### PR TITLE
🗓️ Fixed WSOD on Metric Date Selector

### DIFF
--- a/www/js/metrics/MetricsDateSelect.tsx
+++ b/www/js/metrics/MetricsDateSelect.tsx
@@ -35,19 +35,24 @@ const MetricsDateSelect = ({ dateRange, setDateRange }: Props) => {
 
   const onChoose = useCallback(
     ({ startDate, endDate }) => {
-      const dtStartDate = DateTime.fromJSDate(startDate).startOf('day')
+      const dtStartDate = DateTime.fromJSDate(startDate).startOf('day');
       let dtEndDate;
-      if(!endDate) { // For when only one day is selected
-        dtEndDate = dtStartDate.endOf('day').minus({minutes: 1});
-      }
-      else {
-        dtEndDate = DateTime.fromJSDate(endDate).startOf('day')
+
+      if (!endDate) {
+        // If no end date selected, pull range from then till present day
+        dtEndDate = DateTime.now();
+      } else if (
+        dtStartDate.toString() === DateTime.fromJSDate(endDate).startOf('day').toString()
+      ) {
+        // For when only one day is selected
+        // NOTE: As written, this technically timestamp will technically fetch _two_ days.
+        // For more info, see: https://github.com/e-mission/e-mission-docs/issues/1027
+        dtEndDate = dtStartDate.endOf('day');
+      } else {
+        dtEndDate = DateTime.fromJSDate(endDate).startOf('day');
       }
       setOpen(false);
-      setDateRange([
-        dtStartDate,
-        dtEndDate,
-      ]);
+      setDateRange([dtStartDate, dtEndDate]);
     },
     [setOpen, setDateRange],
   );

--- a/www/js/metrics/MetricsDateSelect.tsx
+++ b/www/js/metrics/MetricsDateSelect.tsx
@@ -35,10 +35,18 @@ const MetricsDateSelect = ({ dateRange, setDateRange }: Props) => {
 
   const onChoose = useCallback(
     ({ startDate, endDate }) => {
+      const dtStartDate = DateTime.fromJSDate(startDate).startOf('day')
+      let dtEndDate;
+      if(!endDate) { // For when only one day is selected
+        dtEndDate = dtStartDate.endOf('day').minus({minutes: 1});
+      }
+      else {
+        dtEndDate = DateTime.fromJSDate(endDate).startOf('day')
+      }
       setOpen(false);
       setDateRange([
-        DateTime.fromJSDate(startDate).startOf('day'),
-        DateTime.fromJSDate(endDate).startOf('day'),
+        dtStartDate,
+        dtEndDate,
       ]);
     },
     [setOpen, setDateRange],
@@ -64,7 +72,7 @@ const MetricsDateSelect = ({ dateRange, setDateRange }: Props) => {
         mode="range"
         visible={open}
         startDate={dateRangeAsJSDate[0]}
-        endDate={dateRangeAsJSDate[1]}
+        endDate={dateRangeAsJSDate[1] ? dateRangeAsJSDate[1] : dateRangeAsJSDate[0]}
         validRange={{ endDate: todayDate }}
         onDismiss={onDismiss}
         onConfirm={onChoose}

--- a/www/js/metrics/MetricsDateSelect.tsx
+++ b/www/js/metrics/MetricsDateSelect.tsx
@@ -72,7 +72,7 @@ const MetricsDateSelect = ({ dateRange, setDateRange }: Props) => {
         mode="range"
         visible={open}
         startDate={dateRangeAsJSDate[0]}
-        endDate={dateRangeAsJSDate[1] ? dateRangeAsJSDate[1] : dateRangeAsJSDate[0]}
+        endDate={dateRangeAsJSDate[1]}
         validRange={{ endDate: todayDate }}
         onDismiss={onDismiss}
         onConfirm={onChoose}


### PR DESCRIPTION
Fix for the WSOD that was reported in issue [1027](https://github.com/e-mission/e-mission-docs/issues/1027) .  Now, when a single day is picked, the range queried is "the full day" of the start date.  

This was an issue on both iOS and Android: I've tested this fix on iOS, but am currently unable to test on Android.  For anyone able to, please let me know if it works on both OSs! 

(PR is to merge into @JGreenlee 's UI wrapup, since it's the most contemporary branch!).

https://github.com/e-mission/e-mission-phone/assets/98350084/4b7ca1c9-59c3-45ad-8bd1-7824e74ddae4

